### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/AppCleaner/AppCleaner.pkg.recipe
+++ b/AppCleaner/AppCleaner.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.d33t5.pkg.AppCleaner</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>net.freemacsoft.AppCleaner</string>
 		<key>NAME</key>
 		<string>AppCleaner</string>
 	</dict>

--- a/Emacs/Emacs.pkg.recipe
+++ b/Emacs/Emacs.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.d33t5.pkg.Emacs</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.gnu.Emacs</string>
 		<key>NAME</key>
 		<string>Emacs</string>
 	</dict>

--- a/Miro/Miro.pkg.recipe
+++ b/Miro/Miro.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.d33t5.pkg.Miro</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.electron.realtimeboard</string>
 		<key>NAME</key>
 		<string>Miro</string>
 	</dict>

--- a/calibre/calibre.pkg.recipe
+++ b/calibre/calibre.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.d33t5.pkg.calibre</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>net.kovidgoyal.calibre</string>
 		<key>NAME</key>
 		<string>calibre</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ AppCleaner/AppCleaner.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/d33t5-recipes/AppCleaner/AppCleaner.pkg.recipe
Processing repos/d33t5-recipes/AppCleaner/AppCleaner.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://freemacsoft.net/appcleaner/updates.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 4070
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.6.0
SparkleUpdateInfoProvider: Found URL https://freemacsoft.net/downloads/AppCleaner_3.6.zip
{'Output': {'url': 'https://freemacsoft.net/downloads/AppCleaner_3.6.zip',
            'version': '3.6.0'}}
URLDownloader
{'Input': {'filename': 'AppCleaner-3.6.0.zip',
           'url': 'https://freemacsoft.net/downloads/AppCleaner_3.6.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/downloads/AppCleaner-3.6.0.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/downloads/AppCleaner-3.6.0.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/downloads/AppCleaner-3.6.0.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/AppCleaner',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename AppCleaner-3.6.0.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/downloads/AppCleaner-3.6.0.zip to ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/AppCleaner
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/AppCleaner/AppCleaner.app',
           'requirement': 'anchor apple generic and identifier '
                          '"net.freemacsoft.AppCleaner" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = X85ZX835W9)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/AppCleaner/AppCleaner.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/AppCleaner/AppCleaner.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/AppCleaner/AppCleaner.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/AppCleaner/AppCleaner.app',
           'version': '3.6.0'}}
AppPkgCreator: BundleID: net.freemacsoft.AppCleaner
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/AppCleaner/AppCleaner.app to ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/payload/Applications/AppCleaner.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'net.freemacsoft.AppCleaner',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/AppCleaner-3.6.0.pkg',
                                                        'version': '3.6.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.6.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/receipts/AppCleaner.pkg-receipt-20210213-234926.plist

The following packages were built:
    Identifier                  Version  Pkg Path                                                                                   
    ----------                  -------  --------                                                                                   
    net.freemacsoft.AppCleaner  3.6.0    ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.AppCleaner/AppCleaner-3.6.0.pkg  
```

## ✅ Emacs/Emacs.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/d33t5-recipes/Emacs/Emacs.pkg.recipe
Processing repos/d33t5-recipes/Emacs/Emacs.pkg.recipe...
EmacsURLProvider
{'Input': {}}
EmacsURLProvider: Found URL as https://emacsformacosx.com/emacs-builds/Emacs-27.1-1-universal.dmg
{'Output': {'url': 'https://emacsformacosx.com/emacs-builds/Emacs-27.1-1-universal.dmg'}}
URLDownloader
{'Input': {'filename': 'Emacs.dmg',
           'url': 'https://emacsformacosx.com/emacs-builds/Emacs-27.1-1-universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 12 Aug 2020 05:22:43 GMT
URLDownloader: Storing new ETag header: "3e59c68-5aca7608e2ec0"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Emacs/downloads/Emacs.dmg
{'Output': {'download_changed': True,
            'etag': '"3e59c68-5aca7608e2ec0"',
            'last_modified': 'Wed, 12 Aug 2020 05:22:43 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Emacs/downloads/Emacs.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Emacs/downloads/Emacs.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Emacs/downloads/Emacs.dmg/Emacs.app',
           'requirement': 'identifier "org.gnu.Emacs" and anchor apple generic '
                          'and certificate 1[field.1.2.840.113635.100.6.2.6] '
                          '/* exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "5BRAQAFB8B"',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Emacs/downloads/Emacs.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.vJ6r8E/Emacs.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.vJ6r8E/Emacs.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.vJ6r8E/Emacs.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Emacs/downloads/Emacs.dmg
AppPkgCreator: Using path '/private/tmp/dmg.H2XUSI/Emacs.app' matched from globbed '/private/tmp/dmg.H2XUSI/*.app'.
AppPkgCreator: Version: 27.1
AppPkgCreator: BundleID: org.gnu.Emacs
AppPkgCreator: Copied /private/tmp/dmg.H2XUSI/Emacs.app to ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Emacs/payload/Applications/Emacs.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.gnu.Emacs',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Emacs/Emacs-27.1.pkg',
                                                        'version': '27.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '27.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Emacs/receipts/Emacs.pkg-receipt-20210213-235119.plist

The following new items were downloaded:
    Download Path                                                                        
    -------------                                                                        
    ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Emacs/downloads/Emacs.dmg  

The following packages were built:
    Identifier     Version  Pkg Path                                                                        
    ----------     -------  --------                                                                        
    org.gnu.Emacs  27.1     ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Emacs/Emacs-27.1.pkg  
```

## ✅ Miro/Miro.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/d33t5-recipes/Miro/Miro.pkg.recipe
Processing repos/d33t5-recipes/Miro/Miro.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Miro.dmg',
           'url': 'https://desktop.miro.com/platforms/darwin/Miro.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Miro/downloads/Miro.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Miro/downloads/Miro.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Miro/downloads/Miro.dmg/*.app',
           'requirement': 'identifier "com.electron.realtimeboard" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'M3GM7MFY7U'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Miro/downloads/Miro.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.D0mwZz/Miro.app' matched from globbed '/private/tmp/dmg.D0mwZz/*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.D0mwZz/Miro.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.D0mwZz/Miro.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.D0mwZz/Miro.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Miro/downloads/Miro.dmg
AppPkgCreator: Using path '/private/tmp/dmg.d3tR0c/Miro.app' matched from globbed '/private/tmp/dmg.d3tR0c/*.app'.
AppPkgCreator: Version: 0.4.7
AppPkgCreator: BundleID: com.electron.realtimeboard
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Miro/Miro-0.4.7.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '0.4.7'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.Miro/receipts/Miro.pkg-receipt-20210213-235126.plist

Nothing downloaded, packaged or imported.
```

## ✅ calibre/calibre.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/d33t5-recipes/calibre/calibre.pkg.recipe
Processing repos/d33t5-recipes/calibre/calibre.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'calibre-[0-9\\.]+\\.dmg',
           'github_repo': 'kovidgoyal/calibre'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex 'calibre-[0-9\.]+\.dmg' among asset(s): calibre-5.11.0-i686.txz, calibre-5.11.0-x86_64.txz, calibre-5.11.0.dmg, calibre-5.11.0.msi, calibre-5.11.0.tar.xz, calibre-64bit-5.11.0.msi, calibre-portable-installer-5.11.0.exe
GitHubReleasesInfoProvider: Selected asset 'calibre-5.11.0.dmg' from release 'version 5.11.0'
{'Output': {'release_notes': 'Release version 5.11.0',
            'url': 'https://github.com/kovidgoyal/calibre/releases/download/v5.11.0/calibre-5.11.0.dmg',
            'version': '5.11.0'}}
URLDownloader
{'Input': {'filename': 'calibre.dmg',
           'url': 'https://github.com/kovidgoyal/calibre/releases/download/v5.11.0/calibre-5.11.0.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.calibre/downloads/calibre.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.calibre/downloads/calibre.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.calibre/downloads/calibre.dmg/calibre.app',
           'requirement': 'identifier "net.kovidgoyal.calibre" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'NTY7FVCEKP'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.calibre/downloads/calibre.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.xwcIsI/calibre.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.xwcIsI/calibre.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.xwcIsI/calibre.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '5.11.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.calibre/downloads/calibre.dmg
AppPkgCreator: Using path '/private/tmp/dmg.Hk014R/calibre.app' matched from globbed '/private/tmp/dmg.Hk014R/*.app'.
AppPkgCreator: BundleID: net.kovidgoyal.calibre
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.calibre/calibre-5.11.0.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '5.11.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.calibre/receipts/calibre.pkg-receipt-20210213-235155.plist

Nothing downloaded, packaged or imported.
```

