### PR TITLE
Change parent of draw.io pkg/munki recipes, deprecate download recipe

### DIFF
--- a/draw.io/draw.io.download.recipe
+++ b/draw.io/draw.io.download.recipe
@@ -16,6 +16,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the draw.io recipes in the peshay-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>asset_regex</key>

--- a/draw.io/draw.io.pkg.recipe
+++ b/draw.io/draw.io.pkg.recipe
@@ -14,7 +14,7 @@
 	<key>MinimumVersion</key>
 	<string>2.3</string>
 	<key>ParentRecipe</key>
-	<string>com.github.d33t5.download.draw.io</string>
+	<string>com.github.peshay.download.draw.io</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This PR changes the parent recipes for the draw.io pkg and munki recipes in this repo, and deprecates the draw.io download recipe.

Verbose recipe run output:

```
% autopkg run -vvq draw.io.pkg.recipe
Processing draw.io.pkg.recipe...
WARNING: draw.io.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '(draw.io-universal-.*?\\.dmg)$',
           'github_repo': 'jgraph/drawio-desktop'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '(draw.io-universal-.*?\.dmg)$' among asset(s): draw.io-25.0.2-windows-installer.exe, draw.io-25.0.2-windows-installer.exe.blockmap, draw.io-25.0.2-windows-no-installer.exe, draw.io-25.0.2.msi, draw.io-arm64-25.0.2-windows-arm64-installer.exe, draw.io-arm64-25.0.2-windows-arm64-installer.exe.blockmap, draw.io-arm64-25.0.2-windows-arm64-no-installer.exe, draw.io-arm64-25.0.2.dmg, draw.io-arm64-25.0.2.dmg.blockmap, draw.io-arm64-25.0.2.zip, draw.io-arm64-25.0.2.zip.blockmap, draw.io-ia32-25.0.2-windows-32bit-installer.exe, draw.io-ia32-25.0.2-windows-32bit-installer.exe.blockmap, draw.io-ia32-25.0.2-windows-32bit-no-installer.exe, draw.io-universal-25.0.2.dmg, draw.io-universal-25.0.2.dmg.blockmap, draw.io-x64-25.0.2.dmg, draw.io-x64-25.0.2.dmg.blockmap, draw.io-x64-25.0.2.zip, draw.io-x64-25.0.2.zip.blockmap, drawio-aarch64-25.0.2.rpm, drawio-amd64-25.0.2.deb, drawio-arm64-25.0.2.AppImage, drawio-arm64-25.0.2.deb, drawio-x86_64-25.0.2.AppImage, drawio-x86_64-25.0.2.rpm, latest-linux-arm64.yml, latest-linux.yml, latest-mac.yml, latest.yml
GitHubReleasesInfoProvider: Selected asset 'draw.io-universal-25.0.2.dmg' from release '25.0.2'
{'Output': {'asset_created_at': '2024-12-03T11:28:54Z',
            'asset_url': 'https://api.github.com/repos/jgraph/drawio-desktop/releases/assets/210719593',
            'release_notes': '## Releases Notes for 25.0.2\r\n'
                             '[Windows '
                             'Installer](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-25.0.2-windows-installer.exe)\r\n'
                             '[Windows No '
                             'Installer](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-25.0.2-windows-no-installer.exe)\r\n'
                             '[macOS - '
                             'Universal](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-universal-25.0.2.dmg)\r\n'
                             'Linux - '
                             '[deb](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/drawio-amd64-25.0.2.deb), '
                             '[AppImage](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/drawio-x86_64-25.0.2.AppImage) '
                             'or '
                             '[rpm](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/drawio-x86_64-25.0.2.rpm)\r\n'
                             '\r\n'
                             'Windows intel x32 releases are marked -ia32-\r\n'
                             '\r\n'
                             '**ChangeLog:**\r\n'
                             '\r\n'
                             '- #1922 \r\n'
                             '- Updates to draw.io core 25.0.2\r\n'
                             '- Uses electron 32.2.5\r\n'
                             '- Updates to [draw.io core '
                             '25.0.2](https://github.com/jgraph/drawio/blob/v25.0.2/ChangeLog). '
                             'All changes from 25.0.2 are added in this build.',
            'url': 'https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-universal-25.0.2.dmg',
            'version': '25.0.2'}}
URLDownloader
{'Input': {'url': 'https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-universal-25.0.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 03 Dec 2024 11:29:09 GMT
URLDownloader: Storing new ETag header: "0x8DD138DB43DDB5E"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.draw.io/downloads/draw.io-universal-25.0.2.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD138DB43DDB5E"',
            'last_modified': 'Tue, 03 Dec 2024 11:29:09 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.draw.io/downloads/draw.io-universal-25.0.2.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.draw.io/downloads/draw.io-universal-25.0.2.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.draw.io/downloads/draw.io-universal-25.0.2.dmg/draw.io.app',
           'requirement': 'identifier "com.jgraph.drawio.desktop" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'UZEUFB4N53'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.draw.io/downloads/draw.io-universal-25.0.2.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.HIATsk/draw.io.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.HIATsk/draw.io.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.HIATsk/draw.io.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '25.0.2'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.draw.io/downloads/draw.io-universal-25.0.2.dmg
AppPkgCreator: Using path '/private/tmp/dmg.7oEj99/draw.io.app' matched from globbed '/private/tmp/dmg.7oEj99/*.app'.
AppPkgCreator: BundleID: com.jgraph.drawio.desktop
AppPkgCreator: Copied /private/tmp/dmg.7oEj99/draw.io.app to ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.draw.io/payload/Applications/draw.io.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.jgraph.drawio.desktop',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.d33t5.pkg.draw.io/draw.io-25.0.2.pkg',
                                                        'version': '25.0.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '25.0.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.draw.io/receipts/draw.io.pkg-receipt-20250101-113723.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.draw.io/downloads/draw.io-universal-25.0.2.dmg

The following packages were built:
    Identifier                 Version  Pkg Path
    ----------                 -------  --------
    com.jgraph.drawio.desktop  25.0.2   ~/Library/AutoPkg/Cache/com.github.d33t5.pkg.draw.io/draw.io-25.0.2.pkg
```
