### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Arduino/Arduino-Universal.pkg.recipe.yaml
+++ b/Arduino/Arduino-Universal.pkg.recipe.yaml
@@ -35,7 +35,6 @@ Process:
             path: Applications
             user: root
         id: '%bundleid%'
-        options: purge_ds_store
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgname: '%NAME%-arm64-%version%'
 
@@ -58,7 +57,6 @@ Process:
             path: Applications
             user: root
         id: '%bundleid%'
-        options: purge_ds_store
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgname: '%NAME%-x86_64-%version%'
 
@@ -90,7 +88,6 @@ Process:
       pkg_request:
         id: '%bundleid%'
         version: '%version%'
-        options: purge_ds_store
         pkgname: '%NAME%-Universal-%version%'
         pkgdir: '%RECIPE_CACHE_DIR%'
         scripts: '%RECIPE_CACHE_DIR%/Universal/Scripts'

--- a/Giorgio Tani/PeaZip-Universal.pkg.recipe.yaml
+++ b/Giorgio Tani/PeaZip-Universal.pkg.recipe.yaml
@@ -35,7 +35,6 @@ Process:
             path: Applications
             user: root
         id: '%bundleid%'
-        options: purge_ds_store
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgname: '%NAME%-arm64-%version%'
 
@@ -58,7 +57,6 @@ Process:
             path: Applications
             user: root
         id: '%bundleid%'
-        options: purge_ds_store
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgname: '%NAME%-x86_64-%version%'
 
@@ -90,7 +88,6 @@ Process:
       pkg_request:
         id: '%bundleid%'
         version: '%version%'
-        options: purge_ds_store
         pkgname: '%NAME%-Universal-%version%'
         pkgdir: '%RECIPE_CACHE_DIR%'
         scripts: '%RECIPE_CACHE_DIR%/Universal/Scripts'

--- a/OpenJDK/OpenJDK21.pkg.recipe
+++ b/OpenJDK/OpenJDK21.pkg.recipe
@@ -89,8 +89,6 @@
             <string>net.java.openjdk</string>
             <key>scripts</key>
             <string>Scripts</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._